### PR TITLE
Fix the labeler workflow

### DIFF
--- a/.github/workflows/prLabeler.yml
+++ b/.github/workflows/prLabeler.yml
@@ -9,3 +9,4 @@ jobs:
     - uses: actions/labeler@main
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        configuration-path: .github/labels.yaml


### PR DESCRIPTION
The label config file for the actions/labeler action is
.github/labeler.yml. But the config file is located in
.github/labels.yaml. I've updated the workflow configuration to override
the configuration path with the real location of the file.

Signed-off-by: Carolyn Van Slyck <me@carolynvanslyck.com>